### PR TITLE
Remove test project reference

### DIFF
--- a/Dfc.ProviderPortal.Courses.sln
+++ b/Dfc.ProviderPortal.Courses.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 16.0.28922.388
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dfc.ProviderPortal.Courses", "src\Dfc.ProviderPortal.Courses\Dfc.ProviderPortal.Courses.csproj", "{E18D9853-A1D3-4B94-8E90-4501AEFF983F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DFC.ProviderPortal.Courses.Tests", "tests\DFC.ProviderPortal.Courses.Tests\DFC.ProviderPortal.Courses.Tests.csproj", "{6A48D484-957D-4838-929A-CE5B10A168E8}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,10 +15,6 @@ Global
 		{E18D9853-A1D3-4B94-8E90-4501AEFF983F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E18D9853-A1D3-4B94-8E90-4501AEFF983F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E18D9853-A1D3-4B94-8E90-4501AEFF983F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{6A48D484-957D-4838-929A-CE5B10A168E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{6A48D484-957D-4838-929A-CE5B10A168E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{6A48D484-957D-4838-929A-CE5B10A168E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{6A48D484-957D-4838-929A-CE5B10A168E8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Missed this with the `rm -rf` of the broken tests in #162 