### PR TITLE
[PTCD-636] Switch delete to soft delete (aka archive)

### DIFF
--- a/src/Dfc.ProviderPortal.Courses/Functions/DeleteBulkUploadCourses.cs
+++ b/src/Dfc.ProviderPortal.Courses/Functions/DeleteBulkUploadCourses.cs
@@ -1,17 +1,12 @@
 using System;
-using System.IO;
+using System.Net.Http;
 using System.Threading.Tasks;
+using Dfc.ProviderPortal.Courses.Interfaces;
+using Dfc.ProviderPortal.Packages.AzureFunctions.DependencyInjection;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
-using Dfc.ProviderPortal.Packages.AzureFunctions.DependencyInjection;
-using Dfc.ProviderPortal.Courses.Interfaces;
-using System.Net.Http;
-using System.Collections.Generic;
-using Dfc.ProviderPortal.Courses.Models;
 
 namespace Dfc.ProviderPortal.Courses.Functions
 {
@@ -27,8 +22,6 @@ namespace Dfc.ProviderPortal.Courses.Functions
             string strUKPRN = req.RequestUri.ParseQueryString()["UKPRN"]?.ToString()
                                 ?? (await (dynamic)req.Content.ReadAsAsync<object>())?.UKPRN;
 
-            List<string> messagesList = null;
-
             if (string.IsNullOrWhiteSpace(strUKPRN))
                 return new BadRequestObjectResult($"Empty or missing UKPRN value.");
 
@@ -37,13 +30,9 @@ namespace Dfc.ProviderPortal.Courses.Functions
 
             try
             {
-                messagesList = await coursesService.DeleteBulkUploadCourses(UKPRN);
-
-                if (messagesList == null)
-                    return new NotFoundObjectResult(UKPRN);
-
-                return new OkObjectResult(messagesList);
-
+                var result = await coursesService.ArchivePendingBulkUploadCourseRunsByUKPRN(UKPRN);
+                result.EnsureSuccessStatusCode();
+                return new OkResult();
             }
             catch (Exception e)
             {

--- a/src/Dfc.ProviderPortal.Courses/Functions/DeleteBulkUploadCourses.cs
+++ b/src/Dfc.ProviderPortal.Courses/Functions/DeleteBulkUploadCourses.cs
@@ -47,6 +47,7 @@ namespace Dfc.ProviderPortal.Courses.Functions
             }
             catch (Exception e)
             {
+                log.LogError("call to coursesService.ArchiveCourseRunsByUKPRN failed", e);
                 return new InternalServerErrorObjectResult(e);
             }
             finally

--- a/src/Dfc.ProviderPortal.Courses/Functions/DeleteCoursesByUKPRN.cs
+++ b/src/Dfc.ProviderPortal.Courses/Functions/DeleteCoursesByUKPRN.cs
@@ -45,6 +45,7 @@ namespace Dfc.ProviderPortal.Courses.Functions
             }
             catch (Exception e)
             {
+                log.LogError("call to coursesService.ArchiveCourseRunsByUKPRN failed", e);
                 return new InternalServerErrorObjectResult(e);
             }
         }

--- a/src/Dfc.ProviderPortal.Courses/Helpers/CosmosDbHelper.cs
+++ b/src/Dfc.ProviderPortal.Courses/Helpers/CosmosDbHelper.cs
@@ -147,35 +147,6 @@ namespace Dfc.ProviderPortal.Courses.Helpers
             return docs == null ? new List<T>() : await docs.ToListAsync();
         }
 
-        public async Task<List<string>> DeleteDocumentsByUKPRN(DocumentClient client, string collectionId, int UKPRN)
-        {
-            Throw.IfNull(client, nameof(client));
-            Throw.IfNullOrWhiteSpace(collectionId, nameof(collectionId));
-            Throw.IfNull(UKPRN, nameof(UKPRN));
-
-            Uri uri = UriFactory.CreateDocumentCollectionUri(_settings.DatabaseId, collectionId);
-            FeedOptions options = new FeedOptions { EnableCrossPartitionQuery = true, MaxItemCount = -1 };
-
-            List<Models.Course> docs = client.CreateDocumentQuery<Course>(uri, options)
-                                             .Where(x => x.ProviderUKPRN == UKPRN)
-                                             .ToList();
-
-            var responseList = new List<string>();
-
-            foreach (var doc in docs)
-            {
-                Uri docUri = UriFactory.CreateDocumentUri(_settings.DatabaseId, collectionId, doc.id.ToString());
-                var result = await client.DeleteDocumentAsync(docUri, new RequestOptions() { PartitionKey = new PartitionKey(doc.ProviderUKPRN) });
-
-                if (result.StatusCode == HttpStatusCode.NoContent)
-                    responseList.Add($"Course with LARS ( { doc.LearnAimRef } ) and Title ( { doc.QualificationCourseTitle } ) was deleted.");
-                else
-                    responseList.Add($"Course with LARS ( { doc.LearnAimRef } ) and Title ( { doc.QualificationCourseTitle } ) wasn't deleted. StatusCode: ( { result.StatusCode } )");
-            }
-
-            return responseList;
-        }
-
         public async Task<List<string>> DeleteBulkUploadCourses(DocumentClient client, string collectionId, int UKPRN)
         {
             Throw.IfNull(client, nameof(client));

--- a/src/Dfc.ProviderPortal.Courses/Helpers/CosmosDbHelper.cs
+++ b/src/Dfc.ProviderPortal.Courses/Helpers/CosmosDbHelper.cs
@@ -147,40 +147,6 @@ namespace Dfc.ProviderPortal.Courses.Helpers
             return docs == null ? new List<T>() : await docs.ToListAsync();
         }
 
-        public async Task<List<string>> DeleteBulkUploadCourses(DocumentClient client, string collectionId, int UKPRN)
-        {
-            Throw.IfNull(client, nameof(client));
-            Throw.IfNullOrWhiteSpace(collectionId, nameof(collectionId));
-            Throw.IfNull(UKPRN, nameof(UKPRN));
-
-            Uri uri = UriFactory.CreateDocumentCollectionUri(_settings.DatabaseId, collectionId);
-            FeedOptions options = new FeedOptions { EnableCrossPartitionQuery = true, MaxItemCount = -1 };
-
-            List<Models.Course> bulkUploadDocs = client.CreateDocumentQuery<Course>(uri, options)
-                                             .Where(x => x.ProviderUKPRN == UKPRN)
-                                             .Where((y => ((int)y.CourseStatus & (int)RecordStatus.BulkUploadPending) > 0 || ((int)y.CourseStatus & (int)RecordStatus.BulkUploadReadyToGoLive) > 0))
-                                             .ToList();
-
-            var responseList = new List<string>();
-
-            foreach (var doc in bulkUploadDocs)
-            {
-                Uri docUri = UriFactory.CreateDocumentUri(_settings.DatabaseId, collectionId, doc.id.ToString());
-                var result = await client.DeleteDocumentAsync(docUri, new RequestOptions() { PartitionKey = new PartitionKey(doc.ProviderUKPRN) });
-
-                if (result.StatusCode == HttpStatusCode.NoContent)
-                {
-                    responseList.Add($"Course with LARS ( { doc.LearnAimRef } ) and Title ( { doc.QualificationCourseTitle } ) was deleted.");
-                }
-                else
-                {
-                    responseList.Add($"Course with LARS ( { doc.LearnAimRef } ) and Title ( { doc.QualificationCourseTitle } ) wasn't deleted. StatusCode: ( { result.StatusCode } )");
-                }
-            }
-
-            return responseList;
-        }
-
         public async Task<List<DfcMigrationReport>> GetAllDfcMigrationReports(DocumentClient client, string collectionId)
         {
             var reports = new List<DfcMigrationReport>();

--- a/src/Dfc.ProviderPortal.Courses/Interfaces/ICosmosDbHelper.cs
+++ b/src/Dfc.ProviderPortal.Courses/Interfaces/ICosmosDbHelper.cs
@@ -19,7 +19,6 @@ namespace Dfc.ProviderPortal.Courses.Interfaces
         Task<Document> GetDocumentByIdAsync<T>(DocumentClient client, string collectionId, T id);
         Task<Document> UpdateDocumentAsync(DocumentClient client, string collectionId, object document);
         Task<List<Course>> GetDocumentsByUKPRN(DocumentClient client, string collectionId, int UKPRN);
-        Task<List<string>> DeleteBulkUploadCourses(DocumentClient client, string collectionId, int UKPRN);
         Task<List<T>> GetDocumentsByUKPRN<T>(DocumentClient client, string collectionId, int UKPRN);
         Task<List<DfcMigrationReport>> GetAllDfcMigrationReports(DocumentClient client, string collectionId);
         Task<int> GetTotalLiveCourses(DocumentClient client, string collectionId);

--- a/src/Dfc.ProviderPortal.Courses/Interfaces/ICosmosDbHelper.cs
+++ b/src/Dfc.ProviderPortal.Courses/Interfaces/ICosmosDbHelper.cs
@@ -19,7 +19,6 @@ namespace Dfc.ProviderPortal.Courses.Interfaces
         Task<Document> GetDocumentByIdAsync<T>(DocumentClient client, string collectionId, T id);
         Task<Document> UpdateDocumentAsync(DocumentClient client, string collectionId, object document);
         Task<List<Course>> GetDocumentsByUKPRN(DocumentClient client, string collectionId, int UKPRN);
-        Task<List<string>> DeleteDocumentsByUKPRN(DocumentClient client, string collectionId, int UKPRN);
         Task<List<string>> DeleteBulkUploadCourses(DocumentClient client, string collectionId, int UKPRN);
         Task<List<T>> GetDocumentsByUKPRN<T>(DocumentClient client, string collectionId, int UKPRN);
         Task<List<DfcMigrationReport>> GetAllDfcMigrationReports(DocumentClient client, string collectionId);

--- a/src/Dfc.ProviderPortal.Courses/Interfaces/ICourseService.cs
+++ b/src/Dfc.ProviderPortal.Courses/Interfaces/ICourseService.cs
@@ -13,7 +13,6 @@ namespace Dfc.ProviderPortal.Courses.Interfaces
         Task<ICourse> GetCourseById(Guid id);
         Task<AzureSearchCourseDetail> GetCourseSearchDataById(Guid CourseId, Guid RunId);
         Task<IEnumerable<ICourse>> GetCoursesByUKPRN(int UKPRN);
-        Task<List<string>> DeleteCoursesByUKPRN(int UKPRN);
         Task<List<string>> DeleteBulkUploadCourses(int UKPRN);
         Task<ICourse> Update(ICourse doc);
         Task<IEnumerable<ICourse>> GetAllCourses(ILogger log);

--- a/src/Dfc.ProviderPortal.Courses/Interfaces/ICourseService.cs
+++ b/src/Dfc.ProviderPortal.Courses/Interfaces/ICourseService.cs
@@ -13,12 +13,12 @@ namespace Dfc.ProviderPortal.Courses.Interfaces
         Task<ICourse> GetCourseById(Guid id);
         Task<AzureSearchCourseDetail> GetCourseSearchDataById(Guid CourseId, Guid RunId);
         Task<IEnumerable<ICourse>> GetCoursesByUKPRN(int UKPRN);
-        Task<List<string>> DeleteBulkUploadCourses(int UKPRN);
         Task<ICourse> Update(ICourse doc);
         Task<IEnumerable<ICourse>> GetAllCourses(ILogger log);
         Task<HttpResponseMessage> ArchiveProvidersLiveCourses(int UKPRN, int UIMode);
         Task<HttpResponseMessage> ChangeCourseRunStatusesForUKPRNSelection(int UKPRN, RecordStatus CurrentStatus, RecordStatus StatusToBeChangedTo);
         Task<HttpResponseMessage> ArchiveCourseRunsByUKPRN(int UKPRN);
+        Task<HttpResponseMessage> ArchivePendingBulkUploadCourseRunsByUKPRN(int UKPRN);
         Task<HttpResponseMessage> ChangeAllCourseRunStatusesForUKPRNSelection(int UKPRN, RecordStatus StatusToBeChangedTo);
         Task<HttpResponseMessage> UpdateStatus(Guid courseId, Guid courseRunId, int status);
         Task<int> GetTotalLiveCourses();

--- a/src/Dfc.ProviderPortal.Courses/Services/CoursesService.cs
+++ b/src/Dfc.ProviderPortal.Courses/Services/CoursesService.cs
@@ -201,19 +201,6 @@ namespace Dfc.ProviderPortal.Courses.Services
             return persisted;
         }
 
-        public async Task<List<string>> DeleteBulkUploadCourses(int UKPRN)
-        {
-            Throw.IfNull<int>(UKPRN, nameof(UKPRN));
-            Throw.IfLessThan(0, UKPRN, nameof(UKPRN));
-
-            List<string> results = null;
-            using (var client = _cosmosDbHelper.GetClient())
-            {
-                results = await _cosmosDbHelper.DeleteBulkUploadCourses(client, _settings.CoursesCollectionId, UKPRN);
-            }
-
-            return results;
-        }
         public async Task<HttpResponseMessage> ArchiveProvidersLiveCourses(int UKPRN, int UIMode)
         {
             Throw.IfNull<int>(UKPRN, nameof(UKPRN));
@@ -322,6 +309,37 @@ namespace Dfc.ProviderPortal.Courses.Services
 
                             await _cosmosDbHelper.UpdateDocumentAsync(client, _settings.CoursesCollectionId, course);
                         }
+                    }
+
+                    return new HttpResponseMessage(HttpStatusCode.OK);
+                }
+            }
+            catch (Exception)
+            {
+                return new HttpResponseMessage(HttpStatusCode.ExpectationFailed);
+            }
+        }
+
+        public async Task<HttpResponseMessage> ArchivePendingBulkUploadCourseRunsByUKPRN(int UKPRN)
+        {
+            Throw.IfNull<int>(UKPRN, nameof(UKPRN));
+            Throw.IfLessThan(0, UKPRN, nameof(UKPRN));
+
+            try
+            {
+                using (var client = _cosmosDbHelper.GetClient())
+                {
+                    var coursesToUpdate =  await _cosmosDbHelper.GetDocumentsByUKPRN(client, _settings.CoursesCollectionId, UKPRN);
+
+                    foreach (var course in coursesToUpdate.Where(
+                        course =>
+                            ((int)course.CourseStatus & (int)RecordStatus.BulkUploadPending) > 0 ||
+                            ((int)course.CourseStatus & (int)RecordStatus.BulkUploadReadyToGoLive) > 0))
+                    {
+                        course.CourseRuns.Where(cr => cr.RecordStatus != RecordStatus.Archived).ToList()
+                            .ForEach(cr => cr.RecordStatus = RecordStatus.Archived);
+
+                        await _cosmosDbHelper.UpdateDocumentAsync(client, _settings.CoursesCollectionId, course);
                     }
 
                     return new HttpResponseMessage(HttpStatusCode.OK);

--- a/src/Dfc.ProviderPortal.Courses/Services/CoursesService.cs
+++ b/src/Dfc.ProviderPortal.Courses/Services/CoursesService.cs
@@ -201,19 +201,6 @@ namespace Dfc.ProviderPortal.Courses.Services
             return persisted;
         }
 
-        public async Task<List<string>> DeleteCoursesByUKPRN(int UKPRN)
-        {
-            Throw.IfNull<int>(UKPRN, nameof(UKPRN));
-            Throw.IfLessThan(0, UKPRN, nameof(UKPRN));
-
-            List<string> results = null;
-            using (var client = _cosmosDbHelper.GetClient())
-            {
-                results = await _cosmosDbHelper.DeleteDocumentsByUKPRN(client, _settings.CoursesCollectionId, UKPRN);
-            }
-
-            return results;
-        }
         public async Task<List<string>> DeleteBulkUploadCourses(int UKPRN)
         {
             Throw.IfNull<int>(UKPRN, nameof(UKPRN));


### PR DESCRIPTION
[PTCD-636](https://skillsfundingagency.atlassian.net/browse/PTCD-636)

# What?

* Convert the two delete endpoints to use archive instead

# Why?

We *think* that hard delete is causing changes to not show up in the CosmosDB Change Feed Listener (CFL), and as such result in data inconsistency and errors across the system.

# What no tests?

There are no tests in the patch for this change in behaviour because the existing system architecture has made this virtually impossible without major changes. This has been discussed at length with the team and we are resigned to moving forward without test coverage in this instance.

# Course / CourseRun statuses

I'm informed by fellow devs that course status is calculated based on aggregation of course run statuses, so shouldn't be any need to set the status on the actual course. Ideally we'd wnat to clean up the models to prevent inconsistent states, but given the state of the project that will be a big task.

The code currently makes slightly strange use of the two statuses but it's a minimal change given lack of test coverage.

# Manual testing

This has been tested by finding a provider with courses in all the affected statuses, running each function and checking the resultant state of the data. Seems okay.

## Queries
```
-- run+course status counts
SELECT
	c.CourseStatus, r.RecordStatus CourseRun_Status, count(r.id) qty
FROM c
	join r in c.CourseRuns
where c.ProviderUKPRN = 10022802
group by r.RecordStatus, c.CourseStatus
```
```
-- course status counts
SELECT c.CourseStatus, count(c.id) qty
FROM courses c
where c.ProviderUKPRN = 10022802
group by c.CourseStatus
```

## Before running the funcs
```
[
    {
        "CourseStatus": 32,
        "CourseRun_Status": 32,
        "qty": 4
    },
    {
        "CourseStatus": 16,
        "CourseRun_Status": 16,
        "qty": 10
    },
    {
        "CourseStatus": 1,
        "CourseRun_Status": 1,
        "qty": 20
    },
    {
        "CourseStatus": 4,
        "CourseRun_Status": 4,
        "qty": 680
    }
]
```
```
[
    {
        "CourseStatus": 32,
        "qty": 4
    },
    {
        "CourseStatus": 16,
        "qty": 10
    },
    {
        "CourseStatus": 1,
        "qty": 19
    },
    {
        "CourseStatus": 4,
        "qty": 293
    }
]
```
## After bulk upload delete
http://localhost:7071/api/DeleteBulkUploadCourses?ukprn=10022802

```
[
    {
        "CourseStatus": 1,
        "qty": 19
    },
    {
        "CourseStatus": 4,
        "qty": 307
    }
]
```
## After delete live
http://localhost:7071/api/DeleteCoursesByUKPRN?ukprn=10022802
```
[
    {
        "CourseStatus": 4,
        "qty": 326
    }
]
```